### PR TITLE
workflow: Add job to push dependency graph to github

### DIFF
--- a/.github/workflows/push_depgraph.yml
+++ b/.github/workflows/push_depgraph.yml
@@ -1,0 +1,24 @@
+name: CI build
+on:
+  push:
+    branches: [ "main" ]
+  
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Java 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+    - name: Setup Gradle to generate and submit dependency graphs
+      uses: gradle/gradle-build-action@v2
+      with:
+        dependency-graph: generate-and-submit
+    - name: Run the usual CI build (dependency-graph will be generated and submitted post-job)
+      run: ./gradlew build


### PR DESCRIPTION
## Description
Tell github about our dependency graph, based on [https://github.com/marketplace/actions/gradle-build-action]
