### PR TITLE
Add tracking as asset support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("com.google.android.gms:play-services-location:21.1.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/smm/SMMAPI.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/smm/SMMAPI.kt
@@ -24,4 +24,14 @@ interface SMMAPI {
 
     @GET("assets/{assetName}/details/")
     suspend fun getAssetDetails(@Path(value = "assetName") assetName: String): SMMAssetDetails
+
+    @POST("data/assets/{assetName}/position/add/")
+    @FormUrlEncoded
+    suspend fun sendAssetPosition(
+        @Path(value = "assetName") assetName: String,
+        @Field("lat") latitude: Double,
+        @Field("lon") longitude: Double,
+        @Field("fix") fix: Int,
+        @Field("alt") altitude: Int,
+        @Field("heading") heading: Int)
 }

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/AssetActivity.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/AssetActivity.kt
@@ -1,5 +1,8 @@
 package org.canterburyairpatrol.smmclient.ui.activity
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.location.Location
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -9,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -21,8 +25,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -32,12 +40,52 @@ import org.canterburyairpatrol.smmclient.smm.data.SMMAsset
 import org.canterburyairpatrol.smmclient.smm.data.SMMAssetCommand
 import org.canterburyairpatrol.smmclient.smm.data.SMMAssetDetails
 import org.canterburyairpatrol.smmclient.ui.theme.SmmclientandroidTheme
+import java.math.RoundingMode
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
+fun toDMm(v: Double, lat: Boolean) : String
+{
+    val negative = v < 0
+    var point = v
+    if (negative) {
+        point = point * -1.0
+    }
+    val degrees = point.toInt()
+    val minutes = ((point - degrees) * 60.0).toBigDecimal().setScale(4, RoundingMode.HALF_DOWN).toDouble()
+    var direction : String
+
+    if (lat)
+    {
+        if (negative)
+        {
+            direction = "S"
+        }
+        else
+        {
+            direction = "N"
+        }
+    }
+    else
+    {
+        if (negative)
+        {
+            direction = "W"
+        }
+        else
+        {
+            direction = "E"
+        }
+    }
+
+    return "$degrees\u00B0 $minutes $direction"
+}
+
 class AssetActivity : ComponentActivity() {
     private var asset = SMMAsset(0, "", 0, "", "")
+    private lateinit var handler: Handler
+    private lateinit var locationRunnable: Runnable
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -52,6 +100,7 @@ class AssetActivity : ComponentActivity() {
                 receivedAsset?.owner ?: ""
             )
         }
+        handler = Handler()
 
         setContent {
             SmmclientandroidTheme {
@@ -60,7 +109,105 @@ class AssetActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    assetView(this.asset)
+                    Column {
+                        assetView(this@AssetActivity.asset)
+                        positionTracker()
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun positionTracker()
+    {
+        var currentLat by remember { mutableStateOf("unknown") }
+        var currentLon by remember { mutableStateOf("unknown") }
+        var tracking by remember { mutableStateOf(false) }
+        Column () {
+            if (tracking)
+            {
+                Button(onClick = {
+                    handler.removeCallbacks(locationRunnable)
+                    tracking = false
+                }) {
+                    Text("Stop")
+                }
+                Row() {
+                    Text("Lon: $currentLon, ")
+                    Text("Lat: $currentLat")
+                }
+            }
+            else
+            {
+                Button ({
+                    if (ActivityCompat.checkSelfPermission(
+                            this@AssetActivity,
+                            android.Manifest.permission.ACCESS_FINE_LOCATION
+                        ) != PackageManager.PERMISSION_GRANTED
+                    ) {
+                        ActivityCompat.requestPermissions(
+                            this@AssetActivity,
+                            arrayOf(android.Manifest.permission.ACCESS_FINE_LOCATION),
+                            1
+                        )
+                        ActivityCompat.requestPermissions(
+                            this@AssetActivity,
+                            arrayOf(android.Manifest.permission.ACCESS_BACKGROUND_LOCATION),
+                            2
+                        )
+                    }
+                    if (ActivityCompat.checkSelfPermission(
+                            this@AssetActivity,
+                            android.Manifest.permission.ACCESS_FINE_LOCATION
+                        ) == PackageManager.PERMISSION_GRANTED
+                    )
+                    {
+                        locationRunnable = object : Runnable {
+                            override fun run() {
+                                if (ActivityCompat.checkSelfPermission(
+                                        this@AssetActivity,
+                                        Manifest.permission.ACCESS_FINE_LOCATION
+                                    ) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
+                                        this@AssetActivity,
+                                        Manifest.permission.ACCESS_COARSE_LOCATION
+                                    ) != PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    return
+                                }
+                                var fusedLocationClient =
+                                    LocationServices.getFusedLocationProviderClient(this@AssetActivity)
+                                fusedLocationClient.lastLocation.addOnCompleteListener(this@AssetActivity,
+                                    OnCompleteListener { task: Task<Location?> ->
+                                        if (task.isSuccessful && task.result != null) {
+                                            val location: Location = task.result!!
+                                            currentLat = toDMm(location.latitude, true)
+                                            currentLon = toDMm(location.longitude, false)
+                                            val connectionSingleton = ConnectionSingleton.getInstance()
+                                            val api = connectionSingleton.getAPI()
+                                            GlobalScope.launch {
+                                                api.sendAssetPosition(
+                                                    asset.name,
+                                                    location.latitude,
+                                                    location.longitude,
+                                                    (if (location.hasAltitude()) 3 else 2),
+                                                    location.altitude.toInt(),
+                                                    location.bearing.toInt()
+                                                )
+                                            }
+                                        }
+                                    })
+                                // Run again in 1s
+                                handler.postDelayed(this, 1000L)
+                                tracking = true
+                            }
+                        }
+
+                    handler.post(locationRunnable)
+                    }
+                })
+                {
+                    Text("Start Tracking")
                 }
             }
         }

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,6 @@
 ** You should see a list assets associated with your account
 ** Select the Assest you wish to act as
 * On the asset screen:
-
+** Tap the 'Start Tracking' button to enable tracking as the asset you have selected, you will need to give the app permission to access your location.
+** Tap the 'Stop' button to disable tracking
 ## Advanced


### PR DESCRIPTION
## Description
This adds the ability to use the app to track as the selected asset.
Using the start tracking button will display the devices position on the screen and also send that position to the SMM server,
the current update rate is set to 1 second.

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have updated the documentation
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change
