### PR TITLE
build: resolve deprecated warning during build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,5 +12,5 @@ plugins {
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## Description

Fixes a warning that appears during the build

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change