### PR TITLE
login: persist the login details

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("com.google.android.gms:play-services-location:21.2.0")
+    implementation("androidx.preference:preference-ktx:1.2.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/screen/LoginScreen.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/screen/LoginScreen.kt
@@ -3,10 +3,12 @@ package org.canterburyairpatrol.smmclient.ui.screen
 import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -15,10 +17,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.preference.PreferenceManager
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.canterburyairpatrol.smmclient.ConnectionSingleton
@@ -31,52 +35,118 @@ class LoginScreen(private val context: Context) {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     fun Content(onLoginSuccess: () -> Unit) {
-        var connectionDetails by remember { mutableStateOf(SMMConnectionDetails("", "", "")) }
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+        var saveDetails by remember {
+            mutableStateOf(
+                sharedPreferences.getBoolean(
+                    "rememberLogin",
+                    false
+                )
+            )
+        }
+        var connectionDetails by remember {
+            mutableStateOf(
+                SMMConnectionDetails(
+                    sharedPreferences.getString("serverURL", "") ?: "",
+                    sharedPreferences.getString("username", "") ?: "",
+                    sharedPreferences.getString("password", "") ?: ""
+                )
+            )
+        }
         var errorMessage by remember { mutableStateOf("") }
 
-        Column(modifier = Modifier.fillMaxSize()) {
-            OutlinedTextField(
-                value = connectionDetails.serverURL,
-                onValueChange = { connectionDetails = connectionDetails.copy(serverURL = it) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                label = { Text(stringResource(id = R.string.server_url)) },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = true,
-                singleLine = true
-            )
-            OutlinedTextField(
-                value = connectionDetails.username,
-                onValueChange = { connectionDetails = connectionDetails.copy(username = it) },
-                label = { Text(stringResource(R.string.username)) },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = true,
-                singleLine = true
-            )
-            OutlinedTextField(
-                value = connectionDetails.password,
-                onValueChange = { connectionDetails = connectionDetails.copy(password = it) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                visualTransformation = PasswordVisualTransformation(),
-                label = { Text(stringResource(R.string.password)) },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = true,
-                singleLine = true
-            )
-            Button(onClick = {
-                GlobalScope.launch {
-                    var connection = ConnectionSingleton.getInstance()
-                    connection.setConnectionDetails(connectionDetails)
-                    errorMessage = connection.connect()
-                    if (errorMessage == "") {
-                        var intent = Intent(context, AssetSelectorActivity::class.java)
-                        context.startActivity(intent)
-                        onLoginSuccess.invoke()
+        Row(Modifier.fillMaxHeight())
+        {
+            Column(
+                modifier = Modifier.fillMaxWidth().align(Alignment.CenterVertically),
+            ) {
+                OutlinedTextField(
+                    value = connectionDetails.serverURL,
+                    onValueChange = {
+                        connectionDetails = connectionDetails.copy(serverURL = it)
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    label = { Text(stringResource(id = R.string.server_url)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = true,
+                    singleLine = true
+                )
+                OutlinedTextField(
+                    value = connectionDetails.username,
+                    onValueChange = {
+                        connectionDetails = connectionDetails.copy(username = it)
+                    },
+                    label = { Text(stringResource(R.string.username)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = true,
+                    singleLine = true
+                )
+                OutlinedTextField(
+                    value = connectionDetails.password,
+                    onValueChange = {
+                        connectionDetails = connectionDetails.copy(password = it)
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    visualTransformation = PasswordVisualTransformation(),
+                    label = { Text(stringResource(R.string.password)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = true,
+                    singleLine = true
+                )
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.CenterHorizontally),
+                    onClick = {
+                        GlobalScope.launch {
+                            var connection = ConnectionSingleton.getInstance()
+                            connection.setConnectionDetails(connectionDetails)
+                            errorMessage = connection.connect()
+                            if (errorMessage == "") {
+                                val editor = sharedPreferences.edit()
+                                if (saveDetails) {
+                                    editor.putString("serverURL", connectionDetails.serverURL)
+                                    editor.putString("username", connectionDetails.username)
+                                    editor.putString("password", connectionDetails.password)
+                                } else {
+                                    editor.remove("serverURL")
+                                    editor.remove("username")
+                                    editor.remove("password")
+                                }
+                                editor.putBoolean("rememberLogin", saveDetails)
+                                editor.commit()
+                                var intent = Intent(context, AssetSelectorActivity::class.java)
+                                context.startActivity(intent)
+                                onLoginSuccess.invoke()
+                            }
+                        }
+                    }) {
+                    Text(stringResource(id = R.string.connect))
+                }
+                Text(errorMessage)
+                Row(Modifier.fillMaxWidth()) {
+                    Checkbox(checked = saveDetails,
+                        onCheckedChange = {
+                            saveDetails = it
+                        })
+                    Text(
+                        stringResource(R.string.remember_login_details),
+                        modifier = Modifier.align(Alignment.CenterVertically).weight(1f)
+                    )
+                    Button(onClick = {
+                        val editor = sharedPreferences.edit()
+                        editor.remove("serverURL")
+                        editor.remove("username")
+                        editor.remove("password")
+                        editor.remove("rememberLogin")
+                        editor.commit()
+                        connectionDetails = SMMConnectionDetails("", "", "")
+                    }) {
+                        Text(stringResource(id = R.string.forget_login_details))
                     }
                 }
-            }) {
-                Text(stringResource(id = R.string.connect))
             }
-            Text(errorMessage)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="username">Username</string>
     <string name="password">Password</string>
     <string name="connect">Connect</string>
+    <string name="remember_login_details">Remember Login</string>
+    <string name="forget_login_details">Forget Login Details</string>
 </resources>


### PR DESCRIPTION
## Description

Use the PreferenceManager from jetpack to persist the login details across restarts of the app,
the user has the choice to remember their details if they want, and also to forget their details

This makes development easier because everything is already there whenever the app is reloaded

Also, the login screen has been updated to be centered

Resolves #19 

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change