### PR TITLE
Use the asset id to access asset APIs

### DIFF
--- a/app/src/main/java/org/canterburyairpatrol/smmclient/smm/SMMAPI.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/smm/SMMAPI.kt
@@ -22,13 +22,13 @@ interface SMMAPI {
     @GET("assets/mine/json/")
     suspend fun getAssetsMine(): SMMAssetResponse
 
-    @GET("assets/{assetName}/details/")
-    suspend fun getAssetDetails(@Path(value = "assetName") assetName: String): SMMAssetDetails
+    @GET("assets/{assetId}/details/")
+    suspend fun getAssetDetails(@Path(value = "assetId") assetId: Int): SMMAssetDetails
 
-    @POST("data/assets/{assetName}/position/add/")
+    @POST("data/assets/{assetId}/position/add/")
     @FormUrlEncoded
     suspend fun sendAssetPosition(
-        @Path(value = "assetName") assetName: String,
+        @Path(value = "assetId") assetName: Int,
         @Field("lat") latitude: Double,
         @Field("lon") longitude: Double,
         @Field("fix") fix: Int,

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/AssetActivity.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/AssetActivity.kt
@@ -187,7 +187,7 @@ class AssetActivity : ComponentActivity() {
                                             val api = connectionSingleton.getAPI()
                                             GlobalScope.launch {
                                                 api.sendAssetPosition(
-                                                    asset.name,
+                                                    asset.id,
                                                     location.latitude,
                                                     location.longitude,
                                                     (if (location.hasAltitude()) 3 else 2),
@@ -223,7 +223,7 @@ fun assetView(asset: SMMAsset) {
     suspend fun updateAssetDetails() {
         val connectionSingleton = ConnectionSingleton.getInstance()
         val api = connectionSingleton.getAPI()
-        assetDetails = (api.getAssetDetails(asset.name))
+        assetDetails = (api.getAssetDetails(asset.id))
     }
 
     LaunchedEffect(assetDetails) {


### PR DESCRIPTION
## Description

This handles the change in  https://github.com/canterbury-air-patrol/search-management-map/issues/318

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment
- [x] I have tested existing related functionality is not impacted by this change