### PR TITLE
Use a bundle to send asset details

### DIFF
--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/AssetActivity.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/AssetActivity.kt
@@ -90,8 +90,9 @@ class AssetActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val receivedIntent = intent
-        if (receivedIntent != null && receivedIntent.hasExtra("assetDetails")) {
-            val receivedAsset = receivedIntent.getParcelableExtra<SMMAsset>("assetDetails")
+        if (receivedIntent != null && receivedIntent.hasExtra("bundle")) {
+            val bundle = receivedIntent.getBundleExtra("bundle")
+            val receivedAsset = bundle?.getParcelable<SMMAsset>("assetDetails")
             asset = SMMAsset(
                 receivedAsset?.id ?: 0,
                 receivedAsset?.name ?: "",

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/MainSelector.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/activity/MainSelector.kt
@@ -124,7 +124,9 @@ class MainSelectorActivity : ComponentActivity() {
                 AssetListItem(asset = asset,
                     modifier = Modifier.clickable {
                         var intent = Intent(this@MainSelectorActivity, AssetActivity::class.java)
-                        intent.putExtra("assetDetails", asset)
+                        var bundle = Bundle()
+                        bundle.putParcelable("assetDetails", asset)
+                        intent.putExtra("bundle", bundle)
                         startActivity(intent)
                     })
             }


### PR DESCRIPTION
## Description

Not using a bundle was causing an issue on android 7

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Bug Fixes:
- Fixes an issue on Android 7 by using a bundle to pass asset details between activities.