### PR TITLE
Upgrade AGP to 8.8.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-application = "8.7.2"
+application = "8.8.1"
 kotlin = "2.0.20"
 
 ktx = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Nov 18 16:34:05 NZDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

Also updates gradle to 8.10.2

## Checklist
- [x] I/we wrote this code my/ourself
- [x] I have tested this change in my environment

## Summary by Sourcery

Update the Android Gradle Plugin (AGP) to version 8.8.1 and Gradle to version 8.10.2.

Build:
- Update the Android Gradle Plugin (AGP) to version 8.8.1.
- Update Gradle to version 8.10.2.