### PR TITLE
Update AGP to 8.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-application = "8.11.0"
+application = "8.11.1"
 kotlin = "2.2.0"
 
 ktx = "1.16.0"


### PR DESCRIPTION
## Description
Upgrades AGP to 8.11.1 as suggested by latest android studio

## Summary by Sourcery

Build:
- Bump AGP version to 8.11.1 in gradle/libs.versions.toml