### PR TITLE
Update AGP to 8.12.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-application = "8.11.1"
+application = "8.12.0"
 kotlin = "2.2.0"
 
 ktx = "1.16.0"


### PR DESCRIPTION
## Description

Updated by latest android studio

## Checklist
- [x] I have tested this change in my environment

## Summary by Sourcery

Build:
- Bump Android Gradle Plugin version from 8.11.1 to 8.12.0 in libs.versions.toml