### PR TITLE
Move login logic to LoginViewModel

### DIFF
--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,8 +54,10 @@ extensions.configure<ApplicationExtension> {
 
 dependencies {
     implementation(libs.androidx.ktx)
-    implementation(libs.androidx.lifecycle)
+    implementation(libs.androidx.lifecycle.runtime)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity)
+    implementation(libs.androidx.security.crypto)
 
     implementation(platform(libs.androidx.compose))
     implementation(libs.androidx.compose.ui)

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/MainActivity.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/MainActivity.kt
@@ -1,12 +1,23 @@
 package org.canterburyairpatrol.smmclient
 
+import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.core.content.edit
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.preference.PreferenceManager
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import org.canterburyairpatrol.smmclient.ui.activity.MainSelectorActivity
 import org.canterburyairpatrol.smmclient.ui.screen.LoginScreen
+import org.canterburyairpatrol.smmclient.ui.screen.LoginViewModel
 import org.canterburyairpatrol.smmclient.ui.theme.SmmclientandroidTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,12 +31,59 @@ class MainActivity : ComponentActivity() {
                 Surface(
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    val loginScreen = LoginScreen(context = this)
-                    loginScreen.Content {
-                        // Handle login success event here if needed
-                    }
+                    val viewModel: LoginViewModel = viewModel(
+                        factory = object : ViewModelProvider.Factory {
+                            @Suppress("UNCHECKED_CAST")
+                            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                                return LoginViewModel(getEncryptedSharedPreferences()) as T
+                            }
+                        }
+                    )
+                    LoginScreen(
+                        viewModel = viewModel,
+                        onLoginSuccess = {
+                            val intent = Intent(this@MainActivity, MainSelectorActivity::class.java)
+                            startActivity(intent)
+                            finish()
+                        }
+                    )
                 }
             }
         }
+    }
+
+    private fun getEncryptedSharedPreferences(): SharedPreferences {
+        val masterKey = MasterKey.Builder(this)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        val sharedPreferences = EncryptedSharedPreferences.create(
+            this,
+            "secret_shared_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
+        val oldPrefs = PreferenceManager.getDefaultSharedPreferences(this)
+        if (oldPrefs.contains("serverURL") || oldPrefs.contains("username") ||
+            oldPrefs.contains("password") || oldPrefs.contains("rememberLogin")
+        ) {
+            sharedPreferences.edit().apply {
+                putString("serverURL", oldPrefs.getString("serverURL", ""))
+                putString("username", oldPrefs.getString("username", ""))
+                putString("password", oldPrefs.getString("password", ""))
+                putBoolean("rememberLogin", oldPrefs.getBoolean("rememberLogin", false))
+                apply()
+            }
+            oldPrefs.edit(commit = false) {
+                remove("serverURL")
+                remove("username")
+                remove("password")
+                remove("rememberLogin")
+            }
+        }
+
+        return sharedPreferences
     }
 }

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/screen/LoginScreen.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/screen/LoginScreen.kt
@@ -1,150 +1,105 @@
 package org.canterburyairpatrol.smmclient.ui.screen
 
-import android.content.Context
-import android.content.Intent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.preference.PreferenceManager
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import org.canterburyairpatrol.smmclient.ConnectionSingleton
+import androidx.compose.ui.unit.dp
 import org.canterburyairpatrol.smmclient.R
-import org.canterburyairpatrol.smmclient.data.SMMConnectionDetails
-import org.canterburyairpatrol.smmclient.ui.activity.MainSelectorActivity
 
-class LoginScreen(private val context: Context) {
+@Composable
+fun LoginScreen(
+    viewModel: LoginViewModel,
+    onLoginSuccess: () -> Unit
+) {
+    val connectionDetails = viewModel.connectionDetails
+    val saveDetails = viewModel.saveDetails
+    val errorMessage = viewModel.errorMessage
+    val isLoading = viewModel.isLoading
 
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    fun Content(onLoginSuccess: () -> Unit) {
-        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-
-        var saveDetails by remember {
-            mutableStateOf(
-                sharedPreferences.getBoolean(
-                    "rememberLogin",
-                    false
-                )
+    Row(Modifier.fillMaxHeight()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterVertically),
+        ) {
+            OutlinedTextField(
+                value = connectionDetails.serverURL,
+                onValueChange = { viewModel.updateServerURL(it) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                label = { Text(stringResource(id = R.string.server_url)) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isLoading,
+                singleLine = true
             )
-        }
-        var connectionDetails by remember {
-            mutableStateOf(
-                SMMConnectionDetails(
-                    sharedPreferences.getString("serverURL", "") ?: "",
-                    sharedPreferences.getString("username", "") ?: "",
-                    sharedPreferences.getString("password", "") ?: ""
-                )
+            OutlinedTextField(
+                value = connectionDetails.username,
+                onValueChange = { viewModel.updateUsername(it) },
+                label = { Text(stringResource(R.string.username)) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isLoading,
+                singleLine = true
             )
-        }
-        var errorMessage by remember { mutableStateOf("") }
-
-        Row(Modifier.fillMaxHeight())
-        {
-            Column(
-                modifier = Modifier.fillMaxWidth().align(Alignment.CenterVertically),
-            ) {
-                OutlinedTextField(
-                    value = connectionDetails.serverURL,
-                    onValueChange = {
-                        connectionDetails = connectionDetails.copy(serverURL = it)
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-                    label = { Text(stringResource(id = R.string.server_url)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = true,
-                    singleLine = true
-                )
-                OutlinedTextField(
-                    value = connectionDetails.username,
-                    onValueChange = {
-                        connectionDetails = connectionDetails.copy(username = it)
-                    },
-                    label = { Text(stringResource(R.string.username)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = true,
-                    singleLine = true
-                )
-                OutlinedTextField(
-                    value = connectionDetails.password,
-                    onValueChange = {
-                        connectionDetails = connectionDetails.copy(password = it)
-                    },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    visualTransformation = PasswordVisualTransformation(),
-                    label = { Text(stringResource(R.string.password)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = true,
-                    singleLine = true
-                )
-                Button(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.CenterHorizontally),
-                    onClick = {
-                        GlobalScope.launch {
-                            var connection = ConnectionSingleton.getInstance()
-                            connection.setConnectionDetails(connectionDetails)
-                            errorMessage = connection.connect()
-                            if (errorMessage == "") {
-                                val editor = sharedPreferences.edit()
-                                if (saveDetails) {
-                                    editor.putString("serverURL", connectionDetails.serverURL)
-                                    editor.putString("username", connectionDetails.username)
-                                    editor.putString("password", connectionDetails.password)
-                                } else {
-                                    editor.remove("serverURL")
-                                    editor.remove("username")
-                                    editor.remove("password")
-                                }
-                                editor.putBoolean("rememberLogin", saveDetails)
-                                editor.commit()
-                                var intent = Intent(context, MainSelectorActivity::class.java)
-                                context.startActivity(intent)
-                                onLoginSuccess.invoke()
-                            }
-                        }
-                    }) {
+            OutlinedTextField(
+                value = connectionDetails.password,
+                onValueChange = { viewModel.updatePassword(it) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                visualTransformation = PasswordVisualTransformation(),
+                label = { Text(stringResource(R.string.password)) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !isLoading,
+                singleLine = true
+            )
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.CenterHorizontally),
+                enabled = !isLoading,
+                onClick = {
+                    viewModel.login(onLoginSuccess)
+                }) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
                     Text(stringResource(id = R.string.connect))
                 }
+            }
+            if (errorMessage.isNotEmpty()) {
                 Text(errorMessage)
-                Row(Modifier.fillMaxWidth()) {
-                    Checkbox(checked = saveDetails,
-                        onCheckedChange = {
-                            saveDetails = it
-                        })
-                    Text(
-                        stringResource(R.string.remember_login_details),
-                        modifier = Modifier.align(Alignment.CenterVertically).weight(1f)
-                    )
-                    Button(onClick = {
-                        val editor = sharedPreferences.edit()
-                        editor.remove("serverURL")
-                        editor.remove("username")
-                        editor.remove("password")
-                        editor.remove("rememberLogin")
-                        editor.commit()
-                        connectionDetails = SMMConnectionDetails("", "", "")
-                    }) {
-                        Text(stringResource(id = R.string.forget_login_details))
-                    }
+            }
+            Row(Modifier.fillMaxWidth()) {
+                Checkbox(
+                    checked = saveDetails,
+                    onCheckedChange = { viewModel.updateSaveDetails(it) },
+                    enabled = !isLoading
+                )
+                Text(
+                    stringResource(R.string.remember_login_details),
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .weight(1f)
+                )
+                Button(
+                    onClick = { viewModel.forgetDetails() },
+                    enabled = !isLoading
+                ) {
+                    Text(stringResource(id = R.string.forget_login_details))
                 }
             }
         }

--- a/app/src/main/java/org/canterburyairpatrol/smmclient/ui/screen/LoginViewModel.kt
+++ b/app/src/main/java/org/canterburyairpatrol/smmclient/ui/screen/LoginViewModel.kt
@@ -1,0 +1,98 @@
+package org.canterburyairpatrol.smmclient.ui.screen
+
+import android.content.SharedPreferences
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.canterburyairpatrol.smmclient.ConnectionSingleton
+import org.canterburyairpatrol.smmclient.data.SMMConnectionDetails
+
+class LoginViewModel(private val sharedPreferences: SharedPreferences) : ViewModel() {
+
+    var saveDetails by mutableStateOf(sharedPreferences.getBoolean("rememberLogin", false))
+        private set
+
+    var connectionDetails by mutableStateOf(
+        SMMConnectionDetails(
+            sharedPreferences.getString("serverURL", "") ?: "",
+            sharedPreferences.getString("username", "") ?: "",
+            sharedPreferences.getString("password", "") ?: ""
+        )
+    )
+        private set
+
+    var errorMessage by mutableStateOf("")
+        private set
+
+    var isLoading by mutableStateOf(false)
+        private set
+
+    fun updateSaveDetails(save: Boolean) {
+        saveDetails = save
+    }
+
+    fun updateServerURL(url: String) {
+        connectionDetails = connectionDetails.copy(serverURL = url)
+    }
+
+    fun updateUsername(username: String) {
+        connectionDetails = connectionDetails.copy(username = username)
+    }
+
+    fun updatePassword(password: String) {
+        connectionDetails = connectionDetails.copy(password = password)
+    }
+
+    fun login(onLoginSuccess: () -> Unit) {
+        viewModelScope.launch {
+            isLoading = true
+            errorMessage = ""
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    val connection = ConnectionSingleton.getInstance()
+                    connection.setConnectionDetails(connectionDetails)
+                    connection.connect()
+                }
+                if (result == "") {
+                    sharedPreferences.edit().apply {
+                        if (saveDetails) {
+                            putString("serverURL", connectionDetails.serverURL)
+                            putString("username", connectionDetails.username)
+                            putString("password", connectionDetails.password)
+                        } else {
+                            remove("serverURL")
+                            remove("username")
+                            remove("password")
+                        }
+                        putBoolean("rememberLogin", saveDetails)
+                        apply()
+                    }
+                    onLoginSuccess()
+                } else {
+                    errorMessage = result
+                }
+            } catch (e: Exception) {
+                errorMessage = e.message ?: "Unknown error"
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    fun forgetDetails() {
+        sharedPreferences.edit().apply {
+            remove("serverURL")
+            remove("username")
+            remove("password")
+            remove("rememberLogin")
+            apply()
+        }
+        connectionDetails = SMMConnectionDetails("", "", "")
+        saveDetails = false
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ ktx = "1.17.0"
 lifecycle = "2.10.0"
 activity = "1.12.2"
 compose-bom = "2025.12.01"
+security = "1.1.0"
+viewmodel-compose = "2.10.0"
 preferences = "1.2.1"
 junit-ext = "1.1.5"
 espresso-core = "3.5.0"
@@ -19,10 +21,12 @@ okhttp3 = "5.3.2"
 
 [libraries]
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
-androidx-lifecycle = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "viewmodel-compose" }
 androidx-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "activity" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-preferences = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferences" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security" }
 
 androidx-compose = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Summary by Sourcery

Move login state and connection logic into a dedicated ViewModel and wire it into the Compose login screen and hosting activity.

New Features:
- Introduce a LoginViewModel to own login form state, perform connection attempts, and expose loading and error status to the UI.
- Add encrypted storage for login credentials using EncryptedSharedPreferences with automatic migration from legacy shared preferences.
- Show an inline loading indicator on the login button while a login attempt is in progress.

Enhancements:
- Refactor the LoginScreen composable to be stateless and driven entirely by LoginViewModel state and callbacks.
- Update MainActivity to create and provide the LoginViewModel to the login UI and to handle navigation on successful login.

Build:
- Add lifecycle ViewModel Compose and security-crypto libraries to support the new ViewModel and encrypted preferences setup.